### PR TITLE
Make it compatible with react-native 0.81

### DIFF
--- a/android/src/main/java/com/cmsdkreactnativev3/CmSdkReactNativeV3Package.kt
+++ b/android/src/main/java/com/cmsdkreactnativev3/CmSdkReactNativeV3Package.kt
@@ -20,12 +20,12 @@ class CmSdkReactNativeV3Package : TurboReactPackage() {
     return ReactModuleInfoProvider {
       mapOf(
         CmSdkReactNativeV3Module.NAME to ReactModuleInfo(
-          _name = CmSdkReactNativeV3Module.NAME,
-          _className = CmSdkReactNativeV3Module.NAME,
-          _canOverrideExistingModule = false,
-          _needsEagerInit = false,
-          isCxxModule = false,
-          isTurboModule = true
+          CmSdkReactNativeV3Module.NAME,
+          CmSdkReactNativeV3Module.NAME,
+          false,
+          false,
+          false,
+          true
         )
       )
     }


### PR DESCRIPTION
refactor: simplify ReactModuleInfoProvider parameters in CmSdkReactNativeV3Package

This makes it compatible with react-native 0.81.x.
Because of the removal and not only renaming of the parameters it is also compatible with react-native 0.75.x (used in the package)