### PR TITLE
Bumping up to v3.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ android/generated
 /example/.watchman-cookie-Fabios-MacBook-Pro.local-77216-1759
 /init.log
 /reset.log
+/.cursor/plans/hbbtv_pause_bug_2f460dc1.plan.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,6 @@
 #
 .DS_Store
 
-# XDE
-.expo/
-
 # VSCode
 .vscode/
 jsconfig.json
@@ -85,3 +82,6 @@ android/generated
 /package-lock.json
 /example/ios/Podfile.lock
 /yarn.lock
+/example/.watchman-cookie-Fabios-MacBook-Pro.local-77216-1759
+/init.log
+/reset.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ``consentmanager CMP SDK v3.8.0``
+# ``consentmanager CMP SDK v3.10.0``
 
 # cm-sdk-react-native-v3
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -89,5 +89,5 @@ dependencies {
   implementation "androidx.lifecycle:lifecycle-common-java8:2.6.1"
 
   // consentmanager's underlying native Android SDK dependency
-  implementation "net.consentmanager.sdkv3:cmsdkv3:3.8.0"
+  implementation "net.consentmanager.sdkv3:cmsdkv3:3.10.0"
 }

--- a/android/src/main/java/com/cmsdkreactnativev3/CmSdkReactNativeV3Module.kt
+++ b/android/src/main/java/com/cmsdkreactnativev3/CmSdkReactNativeV3Module.kt
@@ -4,6 +4,8 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.app.Activity
+import android.webkit.CookieManager
+import android.webkit.WebStorage
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.Promise
@@ -24,7 +26,7 @@ import net.consentmanager.cm_sdk_android_v3.CMPManagerDelegate
 import net.consentmanager.cm_sdk_android_v3.ConsentLayerUIConfig
 import net.consentmanager.cm_sdk_android_v3.ConsentStatus
 import net.consentmanager.cm_sdk_android_v3.UrlConfig
-import net.consentmanager.cm_sdk_android_v3.UserConsentStatus
+import net.consentmanager.cm_sdk_android_v3.UserChoiceStatus
 
 class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
   ReactContextBaseJavaModule(reactContext), LifecycleEventListener, CMPManagerDelegate {
@@ -37,6 +39,7 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
   private var isInitialized = false
   private var storedATTStatus: Int = 0
   private var isWebViewConfigSet = false
+  private var automaticConsentUpdatesEnabled = true
 
 
   init {
@@ -113,11 +116,13 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
 
       this.webViewConfig = ConsentLayerUIConfig(
         position = position,
-        backgroundStyle = ConsentLayerUIConfig.BackgroundStyle.dimmed(android.graphics.Color.BLACK, 0.5f),
+        backgroundStyle = mapBackgroundStyle(config),
         cornerRadius = cornerRadius,
         respectsSafeArea = if (config.hasKey("respectsSafeArea")) config.getBoolean("respectsSafeArea") else true,
         isCancelable = false,
-        allowsOrientationChanges = if (config.hasKey("allowsOrientationChanges")) config.getBoolean("allowsOrientationChanges") else true
+        allowsOrientationChanges = if (config.hasKey("allowsOrientationChanges")) config.getBoolean("allowsOrientationChanges") else true,
+        darkMode = if (config.hasKey("darkMode")) config.getBoolean("darkMode") else false,
+        navigationBarColor = readOptionalColor(config, "navigationBarColor")
       )
       isWebViewConfigSet = true
 
@@ -135,9 +140,21 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
         val domain = config.getString("domain") ?: throw IllegalArgumentException("Missing 'domain'")
         val language = config.getString("language") ?: throw IllegalArgumentException("Missing 'language'")
         val appName = config.getString("appName") ?: throw IllegalArgumentException("Missing 'appName'")
+        val jsonConfig = if (config.hasKey("jsonConfig")) config.getString("jsonConfig") else null
         val noHash = if (config.hasKey("noHash")) config.getBoolean("noHash") else false
+        val webViewConnectionTimeoutMillis = if (config.hasKey("webViewConnectionTimeoutMillis")) config.getDouble("webViewConnectionTimeoutMillis").toLong() else 3000L
+        val forceRegulation = if (config.hasKey("forceRegulation")) config.getString("forceRegulation") else null
 
-        this.urlConfig = UrlConfig(id, domain, language, appName, noHash = noHash)
+        this.urlConfig = UrlConfig(
+          id = id,
+          domain = domain,
+          language = language,
+          appName = appName,
+          jsonConfig = jsonConfig,
+          noHash = noHash,
+          webViewConnectionTimeoutMillis = webViewConnectionTimeoutMillis,
+          forceRegulation = forceRegulation
+        )
         // Ensure we initialize manager only once and with whatever webViewConfig is currently set
         if (!::cmpManager.isInitialized) {
           initializeCMPManager()
@@ -151,7 +168,7 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
   }
 
   private fun initializeCMPManager() {
-    val activity = currentActivitySafe ?: throw IllegalStateException("Current activity is null")
+    val activity = currentActivitySafe ?: throw IllegalStateException("Current activity is null. Wait until the app is active before calling setUrlConfig().")
     Log.d("CmSdkReactNativeV3", "Initializing CMPManager with activity: $activity, delegate: $this")
 
     cmpManager = CMPManager.getInstance(
@@ -194,30 +211,34 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
    */
   @ReactMethod
   fun getUserStatus(promise: Promise) {
-    try {
-      val userStatus = cmpManager.getUserStatus()
-      val result = Arguments.createMap().apply {
-        putString("hasUserChoice", userStatus.hasUserChoice.toString())
-        putString("tcf", userStatus.tcf)
-        putString("addtlConsent", userStatus.addtlConsent)
-        putString("regulation", userStatus.regulation)
+    withCmpManager(promise) { manager ->
+      try {
+        val userStatus = manager.getUserStatus()
+        val normalizedStatus = mapUserChoiceStatus(userStatus.hasUserChoice)
+        val result = Arguments.createMap().apply {
+          putString("status", normalizedStatus)
+          putString("hasUserChoice", normalizedStatus)
+          putString("tcf", userStatus.tcf)
+          putString("addtlConsent", userStatus.addtlConsent)
+          putString("regulation", userStatus.regulation)
 
-        val vendorsMap = Arguments.createMap()
-        userStatus.vendors.forEach { (vendorId, status) ->
-          vendorsMap.putString(vendorId, status.toString())
-        }
-        putMap("vendors", vendorsMap)
+          val vendorsMap = Arguments.createMap()
+          userStatus.vendors.forEach { (vendorId, status) ->
+            vendorsMap.putString(vendorId, mapConsentStatus(status))
+          }
+          putMap("vendors", vendorsMap)
 
-        val purposesMap = Arguments.createMap()
-        userStatus.purposes.forEach { (purposeId, status) ->
-          purposesMap.putString(purposeId, status.toString())
+          val purposesMap = Arguments.createMap()
+          userStatus.purposes.forEach { (purposeId, status) ->
+            purposesMap.putString(purposeId, mapConsentStatus(status))
+          }
+          putMap("purposes", purposesMap)
         }
-        putMap("purposes", purposesMap)
+
+        promise.resolve(result)
+      } catch (e: Exception) {
+        promise.reject("ERROR", "Failed to get user status: ${e.message}", e)
       }
-
-      promise.resolve(result)
-    } catch (e: Exception) {
-      promise.reject("ERROR", "Failed to get user status: ${e.message}", e)
     }
   }
 
@@ -231,11 +252,13 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
    */
   @ReactMethod
   fun getStatusForPurpose(purposeId: String, promise: Promise) {
-    try {
-      val status = cmpManager.getStatusForPurpose(purposeId)
-      promise.resolve(status.toString())
-    } catch (e: Exception) {
-      promise.reject("ERROR", "Failed to get status for purpose: ${e.message}", e)
+    withCmpManager(promise) { manager ->
+      try {
+        val status = manager.getStatusForPurpose(purposeId)
+        promise.resolve(mapConsentStatus(status))
+      } catch (e: Exception) {
+        promise.reject("ERROR", "Failed to get status for purpose: ${e.message}", e)
+      }
     }
   }
 
@@ -244,11 +267,13 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
    */
   @ReactMethod
   fun getStatusForVendor(vendorId: String, promise: Promise) {
-    try {
-      val status = cmpManager.getStatusForVendor(vendorId)
-      promise.resolve(status.toString())
-    } catch (e: Exception) {
-      promise.reject("ERROR", "Failed to get status for vendor: ${e.message}", e)
+    withCmpManager(promise) { manager ->
+      try {
+        val status = manager.getStatusForVendor(vendorId)
+        promise.resolve(mapConsentStatus(status))
+      } catch (e: Exception) {
+        promise.reject("ERROR", "Failed to get status for vendor: ${e.message}", e)
+      }
     }
   }
 
@@ -257,17 +282,19 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
    */
   @ReactMethod
   fun getGoogleConsentModeStatus(promise: Promise) {
-    try {
-      val consentModeStatus = cmpManager.getGoogleConsentModeStatus()
-      val result = Arguments.createMap()
+    withCmpManager(promise) { manager ->
+      try {
+        val consentModeStatus = manager.getGoogleConsentModeStatus()
+        val result = Arguments.createMap()
 
-      consentModeStatus.forEach { (key, value) ->
-        result.putString(key, value)
+        consentModeStatus.forEach { (key, value) ->
+          result.putString(key, value)
+        }
+
+        promise.resolve(result)
+      } catch (e: Exception) {
+        promise.reject("ERROR", "Failed to get Google Consent Mode status: ${e.message}", e)
       }
-
-      promise.resolve(result)
-    } catch (e: Exception) {
-      promise.reject("ERROR", "Failed to get Google Consent Mode status: ${e.message}", e)
     }
   }
 
@@ -277,16 +304,24 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
   @ReactMethod
   fun isConsentRequired(promise: Promise) {
     scope.launch {
-      try {
-        cmpManager.isConsentRequired { result ->
-          if (result.isSuccess) {
-            promise.resolve(result.getOrNull() ?: false)
-          } else {
-            promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
-          }
+      withCmpManager(promise) { manager ->
+        val activity = currentActivitySafe ?: run {
+          promise.reject("NO_ACTIVITY", "Current activity is null. Wait until the app is active before calling isConsentRequired().")
+          return@withCmpManager
         }
-      } catch (e: Exception) {
-        promise.reject("ERROR", "Failed to check if consent is required: ${e.message}", e)
+
+        try {
+          manager.setActivity(activity)
+          manager.isConsentRequired { result ->
+            if (result.isSuccess) {
+              promise.resolve(result.getOrNull() ?: false)
+            } else {
+              promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+            }
+          }
+        } catch (e: Exception) {
+          promise.reject("ERROR", "Failed to check if consent is required: ${e.message}", e)
+        }
       }
     }
   }
@@ -297,18 +332,24 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
   @ReactMethod
   fun forceOpen(jumpToSettings: Boolean, promise: Promise) {
     scope.launch {
-      try {
-        currentActivitySafe?.let { cmpManager.setActivity(it) }
-
-        cmpManager.forceOpen(jumpToSettings) { result ->
-          if (result.isSuccess) {
-            promise.resolve(true)
-          } else {
-            promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
-          }
+      withCmpManager(promise) { manager ->
+        val activity = currentActivitySafe ?: run {
+          promise.reject("NO_ACTIVITY", "Current activity is null. Wait until the app is active before calling forceOpen().")
+          return@withCmpManager
         }
-      } catch (e: Exception) {
-        promise.reject("ERROR", "Failed to force open consent layer: ${e.message}", e)
+
+        try {
+          manager.setActivity(activity)
+          manager.forceOpen(jumpToSettings) { result ->
+            if (result.isSuccess) {
+              promise.resolve(true)
+            } else {
+              promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+            }
+          }
+        } catch (e: Exception) {
+          promise.reject("ERROR", "Failed to force open consent layer: ${e.message}", e)
+        }
       }
     }
   }
@@ -319,18 +360,24 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
   @ReactMethod
   fun checkAndOpen(jumpToSettings: Boolean, promise: Promise) {
     scope.launch {
-      try {
-        currentActivitySafe?.let { cmpManager.setActivity(it) }
-
-        cmpManager.checkAndOpen(jumpToSettings) { result ->
-          if (result.isSuccess) {
-            promise.resolve(true)
-          } else {
-            promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
-          }
+      withCmpManager(promise) { manager ->
+        val activity = currentActivitySafe ?: run {
+          promise.reject("NO_ACTIVITY", "Current activity is null. Wait until the app is active before calling checkAndOpen().")
+          return@withCmpManager
         }
-      } catch (e: Exception) {
-        promise.reject("ERROR", "Failed to check and open consent: ${e.message}", e)
+
+        try {
+          manager.setActivity(activity)
+          manager.checkAndOpen(jumpToSettings) { result ->
+            if (result.isSuccess) {
+              promise.resolve(true)
+            } else {
+              promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+            }
+          }
+        } catch (e: Exception) {
+          promise.reject("ERROR", "Failed to check and open consent: ${e.message}", e)
+        }
       }
     }
   }
@@ -341,16 +388,18 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
   @ReactMethod
   fun importCMPInfo(cmpString: String, promise: Promise) {
     scope.launch {
-      try {
-        cmpManager.importCMPInfo(cmpString) { result ->
-          if (result.isSuccess) {
-            promise.resolve(true)
-          } else {
-            promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+      withCmpManager(promise) { manager ->
+        try {
+          manager.importCMPInfo(cmpString) { result ->
+            if (result.isSuccess) {
+              promise.resolve(true)
+            } else {
+              promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+            }
           }
+        } catch (e: Exception) {
+          promise.reject("ERROR", "Failed to import CMP info: ${e.message}", e)
         }
-      } catch (e: Exception) {
-        promise.reject("ERROR", "Failed to import CMP info: ${e.message}", e)
       }
     }
   }
@@ -360,34 +409,44 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
    */
   @ReactMethod
   fun resetConsentManagementData(promise: Promise) {
-    try {
-      cmpManager.resetConsentManagementData()
-      promise.resolve(true)
-    } catch (e: Exception) {
-      promise.reject("ERROR", "Failed to reset consent management data: ${e.message}", e)
+    withCmpManager(promise) { manager ->
+      runOnUiThread {
+        try {
+          manager.resetConsentManagementData()
+          clearWebViewStorage {
+            promise.resolve(true)
+          }
+        } catch (e: Exception) {
+          promise.reject("ERROR", "Failed to reset consent management data: ${e.message}", e)
+        }
+      }
     }
   }
 
   @ReactMethod
   fun exportCMPInfo(promise: Promise) {
-    promise.resolve(cmpManager.exportCMPInfo())
+    withCmpManager(promise) { manager ->
+      promise.resolve(manager.exportCMPInfo())
+    }
   }
 
   @ReactMethod
   fun acceptVendors(vendors: ReadableArray, promise: Promise) {
     scope.launch {
-      try {
-        Log.d("CmSdkReactNativeV3", "Accepting vendors: $vendors")
+      withCmpManager(promise) { manager ->
+        try {
+          Log.d("CmSdkReactNativeV3", "Accepting vendors: $vendors")
 
-        cmpManager.acceptVendors(vendors.toListOfStrings()) { result ->
-          if (result.isSuccess) {
-            promise.resolve(null)
-          } else {
-            promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+          manager.acceptVendors(vendors.toListOfStrings()) { result ->
+            if (result.isSuccess) {
+              promise.resolve(true)
+            } else {
+              promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+            }
           }
+        } catch (e: Exception) {
+          promise.reject("ERROR", "Failed to accept vendors: ${e.message}", e)
         }
-      } catch (e: Exception) {
-        promise.reject("ERROR", "Failed to accept vendors: ${e.message}", e)
       }
     }
   }
@@ -395,17 +454,19 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
   @ReactMethod
   fun rejectVendors(vendors: ReadableArray, promise: Promise) {
     scope.launch {
-      try {
-        Log.d("CmSdkReactNativeV3", "Rejecting vendors: $vendors")
-        cmpManager.rejectVendors(vendors.toListOfStrings()) { result ->
-          if (result.isSuccess) {
-            promise.resolve(null)
-          } else {
-            promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+      withCmpManager(promise) { manager ->
+        try {
+          Log.d("CmSdkReactNativeV3", "Rejecting vendors: $vendors")
+          manager.rejectVendors(vendors.toListOfStrings()) { result ->
+            if (result.isSuccess) {
+              promise.resolve(true)
+            } else {
+              promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+            }
           }
+        } catch (e: Exception) {
+          promise.reject("ERROR", "Failed to reject vendors: ${e.message}", e)
         }
-      } catch (e: Exception) {
-        promise.reject("ERROR", "Failed to reject vendors: ${e.message}", e)
       }
     }
   }
@@ -413,18 +474,20 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
   @ReactMethod
   fun acceptPurposes(purposes: ReadableArray, updatePurpose: Boolean, promise: Promise) {
     scope.launch {
-      try {
-        Log.d("Cmsdkreactnativev3", "Rejecting purposes: $purposes")
+      withCmpManager(promise) { manager ->
+        try {
+          Log.d("Cmsdkreactnativev3", "Accepting purposes: $purposes")
 
-        cmpManager.acceptPurposes(purposes.toListOfStrings(), updatePurpose) { result ->
-          if (result.isSuccess) {
-            promise.resolve(null)
-          } else {
-            promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+          manager.acceptPurposes(purposes.toListOfStrings(), updatePurpose) { result ->
+            if (result.isSuccess) {
+              promise.resolve(true)
+            } else {
+              promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+            }
           }
+        } catch (e: Exception) {
+          promise.reject("ERROR", "Failed to accept purposes: ${e.message}", e)
         }
-      } catch (e: Exception) {
-        promise.reject("ERROR", "Failed to accept purposes: ${e.message}", e)
       }
     }
   }
@@ -432,17 +495,19 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
   @ReactMethod
   fun rejectPurposes(purposes: ReadableArray, updateVendor: Boolean, promise: Promise) {
     scope.launch {
-      try {
-        Log.d("Cmsdkreactnativev3", "Rejecting purposes: $purposes")
-        cmpManager.rejectPurposes(purposes.toListOfStrings(), updateVendor) { result ->
-          if (result.isSuccess) {
-            promise.resolve(null)
-          } else {
-            promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+      withCmpManager(promise) { manager ->
+        try {
+          Log.d("Cmsdkreactnativev3", "Rejecting purposes: $purposes")
+          manager.rejectPurposes(purposes.toListOfStrings(), updateVendor) { result ->
+            if (result.isSuccess) {
+              promise.resolve(true)
+            } else {
+              promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+            }
           }
+        } catch (e: Exception) {
+          promise.reject("ERROR", "Failed to reject purposes: ${e.message}", e)
         }
-      } catch (e: Exception) {
-        promise.reject("ERROR", "Failed to reject purposes: ${e.message}", e)
       }
     }
   }
@@ -450,16 +515,18 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
   @ReactMethod
   fun rejectAll(promise: Promise) {
     scope.launch {
-      try {
-        cmpManager.rejectAll { result ->
-          if (result.isSuccess) {
-            promise.resolve(null)
-          } else {
-            promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+      withCmpManager(promise) { manager ->
+        try {
+          manager.rejectAll { result ->
+            if (result.isSuccess) {
+              promise.resolve(true)
+            } else {
+              promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+            }
           }
+        } catch (e: Exception) {
+          promise.reject("ERROR", "Failed to reject all: ${e.message}", e)
         }
-      } catch (e: Exception) {
-        promise.reject("ERROR", "Failed to reject all: ${e.message}", e)
       }
     }
   }
@@ -467,18 +534,97 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
   @ReactMethod
   fun acceptAll(promise: Promise) {
     scope.launch {
-      try {
-        cmpManager.acceptAll { result ->
-          if (result.isSuccess) {
-            promise.resolve(null)
-          } else {
-            promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+      withCmpManager(promise) { manager ->
+        try {
+          manager.acceptAll { result ->
+            if (result.isSuccess) {
+              promise.resolve(true)
+            } else {
+              promise.reject("ERROR", result.exceptionOrNull()?.message ?: "Unknown error")
+            }
           }
+        } catch (e: Exception) {
+          promise.reject("ERROR", "Failed to accept all: ${e.message}", e)
         }
-      } catch (e: Exception) {
-        promise.reject("ERROR", "Failed to accept all: ${e.message}", e)
       }
     }
+  }
+
+  @ReactMethod
+  fun setAutomaticConsentUpdatesEnabled(enabled: Boolean, promise: Promise) {
+    withCmpManager(promise) { manager ->
+      try {
+        automaticConsentUpdatesEnabled = enabled
+        manager.setAutomaticConsentUpdatesEnabled(enabled)
+        promise.resolve(null)
+      } catch (e: Exception) {
+        promise.reject("ERROR", "Failed to set automatic consent updates: ${e.message}", e)
+      }
+    }
+  }
+
+  @ReactMethod
+  fun updateThirdPartyConsent(promise: Promise) {
+    withCmpManager(promise) { manager ->
+      try {
+        val result = Arguments.createMap()
+        manager.updateThirdPartyConsent(reactApplicationContext).forEach { (key, value) ->
+          result.putBoolean(key, value)
+        }
+        promise.resolve(result)
+      } catch (e: Exception) {
+        promise.reject("ERROR", "Failed to update third-party consent: ${e.message}", e)
+      }
+    }
+  }
+
+  private fun mapBackgroundStyle(config: ReadableMap): ConsentLayerUIConfig.BackgroundStyle {
+    val backgroundConfig = if (config.hasKey("backgroundStyle")) config.getMap("backgroundStyle") else null
+    val type = backgroundConfig?.getString("type") ?: return ConsentLayerUIConfig.BackgroundStyle.dimmed(android.graphics.Color.BLACK, 0.5f)
+
+    return when (type) {
+      "dimmed" -> ConsentLayerUIConfig.BackgroundStyle.dimmed(
+        readOptionalColor(backgroundConfig, "color") ?: android.graphics.Color.BLACK,
+        if (backgroundConfig.hasKey("opacity")) backgroundConfig.getDouble("opacity").toFloat() else 0.5f
+      )
+      "color" -> ConsentLayerUIConfig.BackgroundStyle.solid(
+        readOptionalColor(backgroundConfig, "color") ?: android.graphics.Color.BLACK
+      )
+      "blur" -> ConsentLayerUIConfig.BackgroundStyle.blur(
+        readOptionalColor(backgroundConfig, "fallbackColor") ?: android.graphics.Color.BLACK,
+        if (backgroundConfig.hasKey("fallbackOpacity")) backgroundConfig.getDouble("fallbackOpacity").toFloat() else 0.5f
+      )
+      "none" -> ConsentLayerUIConfig.BackgroundStyle.none()
+      else -> ConsentLayerUIConfig.BackgroundStyle.dimmed(android.graphics.Color.BLACK, 0.5f)
+    }
+  }
+
+  private fun readOptionalColor(config: ReadableMap, key: String): Int? {
+    return if (config.hasKey(key) && !config.isNull(key)) config.getDouble(key).toInt() else null
+  }
+
+  private fun mapConsentStatus(status: ConsentStatus): String {
+    return when (status) {
+      ConsentStatus.CHOICE_DOESNT_EXIST -> "choiceDoesntExist"
+      ConsentStatus.GRANTED -> "granted"
+      ConsentStatus.DENIED -> "denied"
+    }
+  }
+
+  private fun mapUserChoiceStatus(status: UserChoiceStatus): String {
+    return when (status) {
+      UserChoiceStatus.CHOICE_EXISTS -> "choiceExists"
+      UserChoiceStatus.CHOICE_DOESNT_EXIST -> "choiceDoesntExist"
+    }
+  }
+
+  private fun withCmpManager(promise: Promise, block: (CMPManager) -> Unit) {
+    if (!::cmpManager.isInitialized) {
+      promise.reject("NOT_INITIALIZED", "CMPManager is not initialized. Call setUrlConfig() first.")
+      return
+    }
+
+    block(cmpManager)
   }
   private fun ReadableArray.toListOfStrings(): List<String> {
     val list = mutableListOf<String>()
@@ -525,6 +671,20 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
     }
   }
 
+  private fun clearWebViewStorage(onComplete: () -> Unit) {
+    try {
+      val cookieManager = CookieManager.getInstance()
+      cookieManager.removeAllCookies {
+        cookieManager.flush()
+        WebStorage.getInstance().deleteAllData()
+        onComplete()
+      }
+    } catch (e: Exception) {
+      Log.w("CmSdkReactNativeV3", "Failed to clear WebView storage: ${e.message}")
+      onComplete()
+    }
+  }
+
   companion object {
     const val NAME = "CmSdkReactNativeV3"
     private var globalCMPManager: CMPManager? = null
@@ -533,6 +693,11 @@ class CmSdkReactNativeV3Module(reactContext: ReactApplicationContext) :
 
   override fun didReceiveConsent(consent: String, jsonObject: Map<String, Any>) {
     Log.d("CmSdkReactNativeV3", "didReceiveConsent called from native SDK with consent: ${consent.take(50)}...")
+    Log.d("CmSdkReactNativeV3", "Consent string length: ${consent.length}")
+    Log.d("CmSdkReactNativeV3", "Consent string class: ${consent.javaClass.name}")
+    Log.d("CmSdkReactNativeV3", "First char code: ${if (consent.isNotEmpty()) consent[0].code else "empty"}")
+    Log.d("CmSdkReactNativeV3", "Last char code: ${if (consent.isNotEmpty()) consent[consent.length - 1].code else "empty"}")
+    
     val params = Arguments.createMap().apply {
       putString("consent", consent)
       putMap("jsonObject", convertMapToWritableMap(jsonObject))

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -2,6 +2,29 @@ ENV['RCT_NEW_ARCH_ENABLED'] = '1'
 ENV['RCT_BRIDGELESS_ENABLED'] = '1'  # RN 0.74+
 ENV['USE_HERMES'] = '1'
 
+def patch_fmt_for_xcode_26!(installer)
+  fmt_base = File.join(installer.sandbox.root.to_s, 'fmt', 'include', 'fmt', 'base.h')
+  if File.exist?(fmt_base)
+    contents = File.read(fmt_base)
+    patched = contents.sub(
+      "#elif defined(__cpp_consteval)\n#  define FMT_USE_CONSTEVAL 1",
+      "#elif defined(__cpp_consteval)\n#  define FMT_USE_CONSTEVAL 0"
+    )
+    if patched != contents
+      File.chmod(0644, fmt_base)
+      File.write(fmt_base, patched)
+    end
+  end
+
+  installer.pods_project.targets.each do |target|
+    next unless target.name == 'fmt'
+
+    target.build_configurations.each do |config|
+      config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
+    end
+  end
+end
+
 ws_dir = Pathname.new(__dir__)
 ws_dir = ws_dir.parent until
   File.exist?("#{ws_dir}/node_modules/react-native-test-app/test_app.rb") ||
@@ -10,4 +33,9 @@ require "#{ws_dir}/node_modules/react-native-test-app/test_app.rb"
 
 workspace 'CmSdkReactNativeV3Example.xcworkspace'
 
-use_test_app!
+use_test_app!(
+  post_install: lambda do |installer|
+    # Work around fmt 11.0.2 failing under Xcode 26.4's stricter consteval checks.
+    patch_fmt_for_xcode_26!(installer)
+  end
+)

--- a/example/src/HomeScreen.tsx
+++ b/example/src/HomeScreen.tsx
@@ -20,7 +20,6 @@ import CmSdkReactNativeV3, {
   addClickLinkListener,
   BackgroundStyle,
   BlurEffectStyle,
-  ATTStatus,
   WebViewPosition,
   type WebViewConfig,
 } from 'cm-sdk-react-native-v3';
@@ -151,6 +150,7 @@ const HomeScreen: React.FC = () => {
         language: 'EN',
         appName: 'CMDemoAppReactNative',
         noHash: true,
+        webViewConnectionTimeoutMillis: 13000,
       });
 
       // iOS-only: Set ATT status if on iOS
@@ -254,9 +254,9 @@ const HomeScreen: React.FC = () => {
       ),
     },
     {
-      title: 'Get Status for Purpose c53',
+      title: 'Get Status for Purpose c54',
       onPress: () => handleApiCall(
-        () => CmSdkReactNativeV3.getStatusForPurpose('c53'),
+        () => CmSdkReactNativeV3.getStatusForPurpose('c54'),
         (result) => `Purpose Status: ${result}`,
         'Failed to get purpose status',
         'getStatusForPurpose'
@@ -281,36 +281,36 @@ const HomeScreen: React.FC = () => {
       ),
     },
     {
-      title: 'Enable Purposes c52 and c53',
+      title: 'Enable Purposes c52 and c54',
       onPress: () => handleApiCall(
-        () => CmSdkReactNativeV3.acceptPurposes(['c52', 'c53'], true),
+        () => CmSdkReactNativeV3.acceptPurposes(['c52', 'c54'], true),
         () => 'Purposes enabled',
         'Failed to enable purposes',
         'acceptPurposes'
       ),
     },
     {
-      title: 'Disable Purposes c52 and c53',
+      title: 'Disable Purposes c52 and c54',
       onPress: () => handleApiCall(
-        () => CmSdkReactNativeV3.rejectPurposes(['c52', 'c53'], true),
+        () => CmSdkReactNativeV3.rejectPurposes(['c52', 'c54'], true),
         () => 'Purposes disabled',
         'Failed to disable purposes',
         'rejectPurposes'
       ),
     },
     {
-      title: 'Enable Vendors s2790 and s2791',
+      title: 'Enable Vendors s1052 and s2612',
       onPress: () => handleApiCall(
-        () => CmSdkReactNativeV3.acceptVendors(['s2790', 's2791']),
+        () => CmSdkReactNativeV3.acceptVendors(['s1052', 's2612']),
         () => 'Vendors Enabled',
         'Failed to enable vendors',
         'acceptVendors'
       ),
     },
     {
-      title: 'Disable Vendors s2790 and s2791',
+      title: 'Disable Vendors s1052 and s2612',
       onPress: () => handleApiCall(
-        () => CmSdkReactNativeV3.rejectVendors(['s2790', 's2791']),
+        () => CmSdkReactNativeV3.rejectVendors(['s1052', 's2612']),
         () => 'Vendors Disabled',
         'Failed to disable vendors',
         'rejectVendors'
@@ -392,7 +392,7 @@ const HomeScreen: React.FC = () => {
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView contentContainerStyle={styles.scrollContent}>
-        <Text style={styles.title}>CM React Native DemoApp v3.8.0</Text>
+        <Text style={styles.title}>CM React Native DemoApp v3.10.0</Text>
         <Text style={styles.subtitle}>Legacy architecture (classic React Native bridge)</Text>
 
         <View style={styles.infoContainer}>

--- a/ios/CmSdkReactNativeV3.mm
+++ b/ios/CmSdkReactNativeV3.mm
@@ -78,6 +78,23 @@ RCT_EXTERN_METHOD(importCMPInfo:(NSString *)cmpString
 RCT_EXTERN_METHOD(resetConsentManagementData:(RCTPromiseResolveBlock)resolve
         reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(configureAutomaticFirebaseConsentUpdates:(BOOL)enabled
+        resolve:(RCTPromiseResolveBlock)resolve
+        reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(setAutomaticFirebaseConsentUpdatesEnabled:(BOOL)enabled
+        resolve:(RCTPromiseResolveBlock)resolve
+        reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(isAutomaticFirebaseConsentUpdatesEnabled:(RCTPromiseResolveBlock)resolve
+        reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(updateFirebaseConsent:(RCTPromiseResolveBlock)resolve
+        reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(isFirebaseAnalyticsAvailable:(RCTPromiseResolveBlock)resolve
+        reject:(RCTPromiseRejectBlock)reject)
+
 // Event emitter support methods
 RCT_EXTERN_METHOD(addListener:(NSString *)eventName)
 RCT_EXTERN_METHOD(removeListeners:(double)count)

--- a/ios/CmSdkReactNativeV3.swift
+++ b/ios/CmSdkReactNativeV3.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import WebKit
 import cm_sdk_ios_v3
 import React
 
@@ -77,6 +78,21 @@ class CmSdkReactNativeV3: RCTEventEmitter, CMPManagerDelegate {
   // MARK: - CMPManagerDelegate methods
 
   @objc public func didReceiveConsent(consent: String, jsonObject: [String: Any]) {
+    print("[CMP iOS] didReceiveConsent called")
+    print("[CMP iOS] consent parameter length: \(consent.count)")
+    print("[CMP iOS] consent first 60 chars: \(String(consent.prefix(60)))")
+    if let firstChar = consent.first {
+      print("[CMP iOS] consent first char: '\(firstChar)' code: \(firstChar.asciiValue ?? 0)")
+    }
+    if let lastChar = consent.last {
+      print("[CMP iOS] consent last char: '\(lastChar)' code: \(lastChar.asciiValue ?? 0)")
+    }
+    print("[CMP iOS] jsonObject keys: \(jsonObject.keys)")
+    if let cmpString = jsonObject["cmpString"] as? String {
+      print("[CMP iOS] jsonObject.cmpString exists! Length: \(cmpString.count)")
+      print("[CMP iOS] Are consent param and jsonObject.cmpString same? \(consent == cmpString)")
+    }
+    
     sendEventIfListening(name: "didReceiveConsent", body: [
       "consent": consent,
       "jsonObject": jsonObject
@@ -111,6 +127,7 @@ class CmSdkReactNativeV3: RCTEventEmitter, CMPManagerDelegate {
         let cornerRadius = CGFloat(config["cornerRadius"] as? Double ?? 5)
         let respectsSafeArea = config["respectsSafeArea"] as? Bool ?? true
         let allowsOrientationChanges = config["allowsOrientationChanges"] as? Bool ?? true
+        let darkMode = config["darkMode"] as? Bool ?? false
 
         let position = self.mapPosition(config: config, respectsSafeArea: respectsSafeArea)
         let backgroundStyle = self.mapBackgroundStyle(config: config)
@@ -120,7 +137,8 @@ class CmSdkReactNativeV3: RCTEventEmitter, CMPManagerDelegate {
           backgroundStyle: backgroundStyle,
           cornerRadius: cornerRadius,
           respectsSafeArea: respectsSafeArea,
-          allowsOrientationChanges: allowsOrientationChanges
+          allowsOrientationChanges: allowsOrientationChanges,
+          darkMode: darkMode
         )
 
         self.cmpManager.setWebViewConfig(uiConfig)
@@ -240,10 +258,22 @@ class CmSdkReactNativeV3: RCTEventEmitter, CMPManagerDelegate {
                     let appName = config["appName"] as? String else {
                   throw NSError(domain: "CmSdkReactNativeV3", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid config parameters"])
               }
+              let jsonConfig = config["jsonConfig"] as? String
               let noHash = config["noHash"] as? Bool ?? false
+              let webViewConnectionTimeoutMillis = (config["webViewConnectionTimeoutMillis"] as? NSNumber)?.intValue ?? 3000
+              let forceRegulation = config["forceRegulation"] as? String
               print("ID: \(id) - Domain: \(domain)")
 
-              let urlConfig = UrlConfig(id: id, domain: domain, language: language, appName: appName, jsonConfig: nil, noHash: noHash)
+              let urlConfig = UrlConfig(
+                id: id,
+                domain: domain,
+                language: language,
+                appName: appName,
+                jsonConfig: jsonConfig,
+                noHash: noHash,
+                webViewConnectionTimeoutMillis: webViewConnectionTimeoutMillis,
+                forceRegulation: forceRegulation
+              )
               print("urlConfig = \(urlConfig)")
               self.cmpManager.setUrlConfig(urlConfig)
               resolve(nil)
@@ -289,13 +319,13 @@ class CmSdkReactNativeV3: RCTEventEmitter, CMPManagerDelegate {
   @objc(getStatusForPurpose:resolve:reject:)
   func getStatusForPurpose(_ purposeId: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
       let status = cmpManager.getStatusForPurpose(id: purposeId)
-      resolve(status.rawValue)
+      resolve(stringValue(for: status))
   }
 
   @objc(getStatusForVendor:resolve:reject:)
   func getStatusForVendor(_ vendorId: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
       let status = cmpManager.getStatusForVendor(id: vendorId)
-      resolve(status.rawValue)
+      resolve(stringValue(for: status))
   }
 
   @objc(getGoogleConsentModeStatus:reject:)
@@ -306,23 +336,29 @@ class CmSdkReactNativeV3: RCTEventEmitter, CMPManagerDelegate {
 
   @objc(checkAndOpen:resolve:reject:)
   func checkAndOpen(_ jumpToSettings: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-      cmpManager.checkAndOpen(jumpToSettings: jumpToSettings) { error in
-          if let error = error {
-              reject("ERROR", "Failed to check and open: \(error.localizedDescription)", error)
-          } else {
-              resolve(true)
-          }
+      runOnMainThread {
+        self.updatePresentingViewControllerIfNeeded()
+        self.cmpManager.checkAndOpen(jumpToSettings: jumpToSettings) { error in
+            if let error = error {
+                reject("ERROR", "Failed to check and open: \(error.localizedDescription)", error)
+            } else {
+                resolve(true)
+            }
+        }
       }
   }
 
   @objc(forceOpen:resolve:reject:)
   func forceOpen(_ jumpToSettings: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-      cmpManager.forceOpen(jumpToSettings: jumpToSettings) { error in
-          if let error = error {
-              reject("ERROR", "Failed to force open: \(error.localizedDescription)", error)
-          } else {
-              resolve(true)
-          }
+      runOnMainThread {
+        self.updatePresentingViewControllerIfNeeded()
+        self.cmpManager.forceOpen(jumpToSettings: jumpToSettings) { error in
+            if let error = error {
+                reject("ERROR", "Failed to force open: \(error.localizedDescription)", error)
+            } else {
+                resolve(true)
+            }
+        }
       }
   }
 
@@ -334,29 +370,29 @@ class CmSdkReactNativeV3: RCTEventEmitter, CMPManagerDelegate {
 
   @objc(acceptVendors:resolve:reject:)
   func acceptVendors(_ vendors: [String], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-      self.cmpManager.acceptVendors(vendors) { success in
-          resolve(success)
-          }
+      self.cmpManager.acceptVendors(vendors) { error in
+        self.resolveBooleanCompletion(error: error, successMessage: "Failed to accept vendors", resolve: resolve, reject: reject)
+      }
   }
 
   @objc(rejectVendors:resolve:reject:)
   func rejectVendors(_ vendors: [String], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-      self.cmpManager.rejectVendors(vendors) { success in
-          resolve(success)
+      self.cmpManager.rejectVendors(vendors) { error in
+        self.resolveBooleanCompletion(error: error, successMessage: "Failed to reject vendors", resolve: resolve, reject: reject)
       }
   }
 
   @objc(acceptPurposes:updatePurpose:resolve:reject:)
   func acceptPurposes(_ purposes: [String], updatePurpose: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-      self.cmpManager.acceptPurposes(purposes, updatePurpose: updatePurpose) { success in
-          resolve(success)
+      self.cmpManager.acceptPurposes(purposes, updatePurpose: updatePurpose) { error in
+        self.resolveBooleanCompletion(error: error, successMessage: "Failed to accept purposes", resolve: resolve, reject: reject)
       }
   }
 
   @objc(rejectPurposes:updateVendor:resolve:reject:)
   func rejectPurposes(_ purposes: [String], updateVendor: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-      self.cmpManager.rejectPurposes(purposes, updateVendor: updateVendor) { success in
-          resolve(success)
+      self.cmpManager.rejectPurposes(purposes, updateVendor: updateVendor) { error in
+        self.resolveBooleanCompletion(error: error, successMessage: "Failed to reject purposes", resolve: resolve, reject: reject)
       }
   }
 
@@ -395,7 +431,43 @@ class CmSdkReactNativeV3: RCTEventEmitter, CMPManagerDelegate {
 
   @objc(resetConsentManagementData:reject:)
   func resetConsentManagementData(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-      self.cmpManager.resetConsentManagementData(completion: { success in resolve(success)})
+      self.cmpManager.resetConsentManagementData { error in
+        if let error = error {
+          reject("ERROR", "Failed to reset consent management data: \(error.localizedDescription)", error)
+          return
+        }
+
+        self.clearWebViewData {
+          resolve(true)
+        }
+      }
+  }
+
+  @objc(configureAutomaticFirebaseConsentUpdates:resolve:reject:)
+  func configureAutomaticFirebaseConsentUpdates(_ enabled: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    CMPManager.configureAutomaticFirebaseConsentUpdates(enabled)
+    resolve(nil)
+  }
+
+  @objc(setAutomaticFirebaseConsentUpdatesEnabled:resolve:reject:)
+  func setAutomaticFirebaseConsentUpdatesEnabled(_ enabled: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    cmpManager.setAutomaticFirebaseConsentUpdatesEnabled(enabled)
+    resolve(nil)
+  }
+
+  @objc(isAutomaticFirebaseConsentUpdatesEnabled:reject:)
+  func isAutomaticFirebaseConsentUpdatesEnabled(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    resolve(cmpManager.isAutomaticFirebaseConsentUpdatesEnabled())
+  }
+
+  @objc(updateFirebaseConsent:reject:)
+  func updateFirebaseConsent(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    resolve(cmpManager.updateFirebaseConsent())
+  }
+
+  @objc(isFirebaseAnalyticsAvailable:reject:)
+  func isFirebaseAnalyticsAvailable(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    resolve(cmpManager.isFirebaseAnalyticsAvailable())
   }
 
   // MARK: - Event emitter methods
@@ -408,5 +480,100 @@ class CmSdkReactNativeV3: RCTEventEmitter, CMPManagerDelegate {
   @objc(removeListeners:)
   override func removeListeners(_ count: Double) {
     super.removeListeners(Double(Int(count)))
+  }
+
+  private func clearWebViewData(completion: @escaping () -> Void) {
+    let dataStore = WKWebsiteDataStore.default()
+    let types = WKWebsiteDataStore.allWebsiteDataTypes()
+    let domainsToClear = [
+      "consentmanager.net",
+      "delivery.consentmanager.net",
+      "a.delivery.consentmanager.net"
+    ]
+
+    DispatchQueue.main.async {
+      dataStore.fetchDataRecords(ofTypes: types) { records in
+        let toDelete = records.filter { record in
+          domainsToClear.contains { domain in
+            record.displayName.contains(domain)
+          }
+        }
+
+        let deleteAndComplete = {
+          self.clearCookiesForDomains(domainsToClear)
+          completion()
+        }
+
+        guard !toDelete.isEmpty else {
+          deleteAndComplete()
+          return
+        }
+
+        dataStore.removeData(ofTypes: types, for: toDelete) {
+          deleteAndComplete()
+        }
+      }
+    }
+  }
+
+  private func clearCookiesForDomains(_ domains: [String]) {
+    let cookieStorage = HTTPCookieStorage.shared
+    cookieStorage.cookies?.forEach { cookie in
+      if domains.contains(where: { domain in cookie.domain.contains(domain) }) {
+        cookieStorage.deleteCookie(cookie)
+      }
+    }
+  }
+
+  private func stringValue(for status: UniqueConsentStatus) -> String {
+    switch status {
+    case .choiceDoesntExist:
+      return "choiceDoesntExist"
+    case .granted:
+      return "granted"
+    case .denied:
+      return "denied"
+    @unknown default:
+      return "choiceDoesntExist"
+    }
+  }
+
+  private func resolveBooleanCompletion(
+    error: NSError?,
+    successMessage: String,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    if let error = error {
+      reject("ERROR", "\(successMessage): \(error.localizedDescription)", error)
+    } else {
+      resolve(true)
+    }
+  }
+
+  private func updatePresentingViewControllerIfNeeded() {
+    if let viewController = currentPresentingViewController() {
+      cmpManager.setPresentingViewController(viewController)
+    }
+  }
+
+  private func currentPresentingViewController() -> UIViewController? {
+    if #available(iOS 13.0, *) {
+      let windowScene = UIApplication.shared.connectedScenes
+        .compactMap { $0 as? UIWindowScene }
+        .first { $0.activationState == .foregroundActive }
+      let rootViewController = windowScene?.windows.first { $0.isKeyWindow }?.rootViewController
+      return topMostViewController(from: rootViewController)
+    }
+
+    return topMostViewController(from: UIApplication.shared.keyWindow?.rootViewController)
+  }
+
+  private func topMostViewController(from rootViewController: UIViewController?) -> UIViewController? {
+    var current = rootViewController
+    while let presented = current?.presentedViewController {
+      current = presented
+    }
+    return current
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cm-sdk-react-native-v3",
-  "version": "3.8.0",
+  "version": "3.10.0",
   "description": "Consent Management React Native Library by consentmanager.net",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/react-native-cm-sdk-react-native-v3.podspec
+++ b/react-native-cm-sdk-react-native-v3.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/iubenda/cm-sdk-react-native-v3.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
-  s.dependency "cm-sdk-ios-v3", "3.8.0"
+  s.dependency "cm-sdk-ios-v3", "3.10.0"
   s.dependency "React-Core"
 end

--- a/src/NativeCmSdkReactNativeV3.ts
+++ b/src/NativeCmSdkReactNativeV3.ts
@@ -26,7 +26,13 @@ export type UrlConfig = {
   domain: string;
   language: string;
   appName: string;
+  /** Optional config override supported by the native SDKs. Reserved for specific CMP setups. */
+  jsonConfig?: string;
   noHash?: boolean;
+  /** WebView connection timeout in ms. Default 3000. 0 = disabled. Clamped 100–60000. */
+  webViewConnectionTimeoutMillis?: number;
+  /** Optional regulation override like `GDPR` or `LGPD`. */
+  forceRegulation?: string;
 };
 
 export enum WebViewPosition {
@@ -66,7 +72,12 @@ export enum ATTStatus {
 export type WebViewBackgroundStyle =
   | { type: BackgroundStyleType.Dimmed; color?: string | number; opacity?: number }
   | { type: BackgroundStyleType.Color; color: string | number }
-  | { type: BackgroundStyleType.Blur; blurEffectStyle?: BlurEffectStyle }
+  | {
+      type: BackgroundStyleType.Blur;
+      blurEffectStyle?: BlurEffectStyle;
+      fallbackColor?: string | number;
+      fallbackOpacity?: number;
+    }
   | { type: BackgroundStyleType.None };
 
 export type WebViewConfig = {
@@ -75,19 +86,25 @@ export type WebViewConfig = {
   cornerRadius?: number;
   respectsSafeArea?: boolean;
   allowsOrientationChanges?: boolean;
+  darkMode?: boolean;
+  /** Android-only. */
+  navigationBarColor?: string | number;
   backgroundStyle?: WebViewBackgroundStyle;
 };
 
 export type UserStatus = {
   status: string;
-  vendors: Object;
-  purposes: Object;
+  /** @deprecated Use `status`. Kept for Android backward compatibility. */
+  hasUserChoice?: string;
+  vendors: Record<string, string>;
+  purposes: Record<string, string>;
   tcf: string;
   addtlConsent: string;
   regulation: string;
 };
 
-export type GoogleConsentModeStatus = Object;
+export type GoogleConsentModeStatus = Record<string, string>;
+export type ThirdPartyConsentStatus = Record<string, boolean>;
 
 export interface CmSdkReactNativeV3Module {
   // Configuration methods
@@ -120,6 +137,17 @@ export interface CmSdkReactNativeV3Module {
   rejectPurposes(purposes: string[], updateVendor: boolean): Promise<boolean>;
   rejectAll(): Promise<boolean>;
   acceptAll(): Promise<boolean>;
+
+  // Android-only native helpers
+  setAutomaticConsentUpdatesEnabled?(enabled: boolean): Promise<void>;
+  updateThirdPartyConsent?(): Promise<ThirdPartyConsentStatus>;
+
+  // iOS-only Firebase helpers
+  configureAutomaticFirebaseConsentUpdates?(enabled: boolean): Promise<void>;
+  setAutomaticFirebaseConsentUpdatesEnabled?(enabled: boolean): Promise<void>;
+  isAutomaticFirebaseConsentUpdatesEnabled?(): Promise<boolean>;
+  updateFirebaseConsent?(): Promise<boolean>;
+  isFirebaseAnalyticsAvailable?(): Promise<boolean>;
 
   // Event emitter methods used by NativeEventEmitter
   addListener(eventName: string): void;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,7 @@ import NativeCmSdkReactNativeV3, {
   ATTStatus,
   type UserStatus,
   type GoogleConsentModeStatus,
+  type ThirdPartyConsentStatus,
   type CmSdkReactNativeV3Module,
 } from './NativeCmSdkReactNativeV3';
 
@@ -21,7 +22,7 @@ import NativeCmSdkReactNativeV3, {
 export { WebViewPosition, BackgroundStyleType, BlurEffectStyle, ATTStatus };
 
 const LINKING_ERROR =
-  `The package 'react-native-cm-sdk-react-native-v3' doesn't seem to be linked. Make sure: \n\n` +
+  `The package 'cm-sdk-react-native-v3' doesn't seem to be linked. Make sure: \n\n` +
   Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo Go\n';
@@ -39,6 +40,17 @@ const CmSdkReactNativeV3: CmSdkReactNativeV3Module =
   ) as CmSdkReactNativeV3Module);
 
 const eventEmitter = new NativeEventEmitter(CmSdkReactNativeV3);
+
+const getOptionalNativeMethod = <T extends keyof CmSdkReactNativeV3Module>(methodName: T) => {
+  const method = CmSdkReactNativeV3[methodName];
+  if (typeof method !== 'function') {
+    throw new Error(
+      `[cm-sdk-react-native-v3] ${String(methodName)} is not available on ${Platform.OS}.`
+    );
+  }
+
+  return method.bind(CmSdkReactNativeV3) as Exclude<CmSdkReactNativeV3Module[T], undefined>;
+};
 
 export const addConsentListener = (
   callback: (consent: string, jsonObject: Object) => void
@@ -134,7 +146,7 @@ const normalizeWebViewConfig = (config: WebViewConfig): WebViewConfig => {
     }
     if (Platform.OS === 'android') {
       console.warn(
-        '[cm-sdk-react-native-v3] Android native SDK currently ignores customRect/position "custom"; it will fall back to full screen.'
+        '[cm-sdk-react-native-v3] Android native SDK uses width/height/gravity for custom positioning, so RN customRect falls back to full screen.'
       );
     }
   }
@@ -170,10 +182,12 @@ const normalizeWebViewConfig = (config: WebViewConfig): WebViewConfig => {
         ) {
           throw new Error(`Invalid blurEffectStyle: ${blurStyle}`);
         }
-        if (Platform.OS === 'android') {
-          console.warn('[cm-sdk-react-native-v3] Android native SDK currently ignores blur backgrounds; using dimmed.');
-        }
-        return { type, blurEffectStyle: blurStyle } as WebViewBackgroundStyle;
+        return {
+          type,
+          blurEffectStyle: blurStyle,
+          fallbackColor: normalizeColor(config.backgroundStyle.fallbackColor ?? 'black'),
+          fallbackOpacity: config.backgroundStyle.fallbackOpacity ?? 0.5,
+        } as WebViewBackgroundStyle;
       }
       case BackgroundStyleType.None:
         return { type } as WebViewBackgroundStyle;
@@ -182,27 +196,23 @@ const normalizeWebViewConfig = (config: WebViewConfig): WebViewConfig => {
     }
   })();
 
-  if (Platform.OS === 'android' && config.backgroundStyle) {
-    console.warn(
-      '[cm-sdk-react-native-v3] Android native SDK currently ignores backgroundStyle overrides; it always uses a dimmed background.'
-    );
-  }
-
   return {
     position,
     customRect: config.customRect,
     cornerRadius: config.cornerRadius ?? 5,
     respectsSafeArea: config.respectsSafeArea ?? true,
     allowsOrientationChanges: config.allowsOrientationChanges ?? true,
+    darkMode: config.darkMode ?? false,
+    navigationBarColor: normalizeColor(config.navigationBarColor),
     backgroundStyle,
   };
 };
 
-const normalizeColor = (color: string | number | undefined) => {
+const normalizeColor = (color: string | number | undefined): number | undefined => {
   if (color === undefined) return undefined;
   const processed = processColor(color);
   if (processed == null) throw new Error(`Invalid color value: ${color}`);
-  return processed;
+  return processed as number;
 };
 
 export const getStatusForPurpose = (purposeId: string): Promise<string> => {
@@ -254,6 +264,34 @@ export const acceptAll = (): Promise<boolean> => {
   return CmSdkReactNativeV3.acceptAll();
 };
 
+export const setAutomaticConsentUpdatesEnabled = (enabled: boolean): Promise<void> => {
+  return getOptionalNativeMethod('setAutomaticConsentUpdatesEnabled')(enabled);
+};
+
+export const updateThirdPartyConsent = (): Promise<ThirdPartyConsentStatus> => {
+  return getOptionalNativeMethod('updateThirdPartyConsent')();
+};
+
+export const configureAutomaticFirebaseConsentUpdates = (enabled: boolean): Promise<void> => {
+  return getOptionalNativeMethod('configureAutomaticFirebaseConsentUpdates')(enabled);
+};
+
+export const setAutomaticFirebaseConsentUpdatesEnabled = (enabled: boolean): Promise<void> => {
+  return getOptionalNativeMethod('setAutomaticFirebaseConsentUpdatesEnabled')(enabled);
+};
+
+export const isAutomaticFirebaseConsentUpdatesEnabled = (): Promise<boolean> => {
+  return getOptionalNativeMethod('isAutomaticFirebaseConsentUpdatesEnabled')();
+};
+
+export const updateFirebaseConsent = (): Promise<boolean> => {
+  return getOptionalNativeMethod('updateFirebaseConsent')();
+};
+
+export const isFirebaseAnalyticsAvailable = (): Promise<boolean> => {
+  return getOptionalNativeMethod('isFirebaseAnalyticsAvailable')();
+};
+
 // Re-export types for consumer convenience
 export type {
   ConsentReceivedEvent,
@@ -266,6 +304,7 @@ export type {
   WebViewConfig,
   UserStatus,
   GoogleConsentModeStatus,
+  ThirdPartyConsentStatus,
 };
 
 /**


### PR DESCRIPTION
## Summary
- bump the React Native bridge and native dependency pins to `3.10.0`
- fix Android bridge lifecycle and initialization issues around `setUrlConfig`, `checkAndOpen`, `forceOpen`, and `isConsentRequired`
- normalize old-arch JS/native API parity across iOS and Android, including `getUserStatus`, consent status values, boolean promise results, and newly exposed native helper APIs

## Test plan
- [x] `yarn typecheck`
- [x] `yarn android` in `example/`
- [ ] smoke test consent flows on iOS example app
- [ ] verify `checkAndOpen`, `forceOpen`, `getUserStatus`, and reset flows on both platforms